### PR TITLE
Add save SVG button to mermaid view panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Export diagrams as markdown to share directly in places that render mermaid (lik
 
 ![outline-view-demo](./assets/gifs/05.gif)
 
+Save the rendered SVG diagram directly from the toolbar.
+
 ## Extension Settings
 
 - `mermaid.searchForExtensions`: Search for Mermaid extensions when viewing Mermaid source.

--- a/media/main.js
+++ b/media/main.js
@@ -14,6 +14,10 @@
                 zoomDiagram(-0.1);
             });
 
+            document.getElementById("save-svg").addEventListener("click", () => {
+                saveSvg();
+            });
+
             document.getElementById("mermaid-diagram").addEventListener("wheel", (event) => {
                 if (event.ctrlKey) {
                     event.preventDefault();
@@ -85,5 +89,37 @@
         }
     }
 
-})();
+    async function saveSvg() {
+        const svgElement = document.querySelector("#mermaid-diagram svg");
+        if (!svgElement) {
+            console.error("No SVG element found");
+            return;
+        }
 
+        const serializer = new XMLSerializer();
+        const svgString = serializer.serializeToString(svgElement);
+        const blob = new Blob([svgString], { type: "image/svg+xml" });
+        const url = URL.createObjectURL(blob);
+
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = await generateFileName();
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
+
+    async function generateFileName() {
+        const date = new Date();
+        const timestamp = date.toISOString().replace(/[:.-]/g, "");
+        const prompt = `Generate a reasonable file name for an SVG diagram. Current timestamp: ${timestamp}`;
+        const response = await vscode.commands.executeCommand('vscode.executeLanguageModel', {
+            prompt,
+            maxTokens: 10,
+            temperature: 0.5,
+        });
+        return response?.text ?? `diagram_${timestamp}.svg`;
+    }
+
+})();

--- a/media/styles.css
+++ b/media/styles.css
@@ -33,3 +33,16 @@
 .clickable .nodeLabel {
     text-decoration: underline;
 }
+
+#save-svg {
+    background-color: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    border: 1px solid var(--vscode-button-border);
+    border-radius: 2px;
+    padding: 4px 8px;
+    cursor: pointer;
+}
+
+#save-svg:hover {
+    background-color: var(--vscode-button-hoverBackground);
+}


### PR DESCRIPTION
Add a "Save SVG" button to the mermaid view panel to save the rendered SVG diagram.

* **media/main.js**
  - Add an event listener to the "save-svg" button to trigger the SVG saving function.
  - Implement the `saveSvg` function to convert the rendered SVG to a downloadable file.
  - Implement the `generateFileName` function to generate the file name automatically using a timestamp and LLM.

* **media/styles.css**
  - Add CSS styles for the new "save-svg" button in the toolbar.

* **README.md**
  - Update the features section to include the new "Save SVG" button functionality.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HyunggyuJang/vscode-mermAId/pull/1?shareId=8fb6a699-3acd-459c-bfc8-20673f7c6231).